### PR TITLE
Use current function name if present when choosing a test case to run

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -103,9 +103,9 @@ The slash is expected at the end."
   "TODO: FIX DOC ."
   (number-to-string (current-column)))
 
-(defun meghanada--what-word ()
+(defun meghanada--what-symbol ()
   "TODO: FIX DOC ."
-  (thing-at-point 'word))
+  (thing-at-point 'symbol))
 
 (defmacro meghanada--without-narrowing (&rest body)
   "TODO: FIX DOC BODY."
@@ -880,7 +880,7 @@ The slash is expected at the end."
                                (buffer-file-name)
                                (meghanada--what-line)
                                (meghanada--what-column)
-                               (meghanada--what-word))
+                               (meghanada--what-symbol))
     (message "client connection not established")))
 
 (defun meghanada-back-jump ()

--- a/meghanada.el
+++ b/meghanada.el
@@ -23,6 +23,7 @@
 (require 'compile)
 (require 'imenu)
 (require 'url)
+(require 'which-func)
 
 (autoload 'meghanada-company-enable "company-meghanada")
 (autoload 'meghanada-flycheck-enable "flycheck-meghanada")
@@ -825,7 +826,10 @@ The slash is expected at the end."
          (class-name (car (split-string
                            (car (last (split-string file-name "/")))
                            "\\.")))
-         (test-case (car (imenu-choose-buffer-index "Test case: ")))
+         (test-case (completing-read "Test case: "
+                                     (imenu--make-index-alist t)
+                                     nil t
+                                     (which-function)))
          (test-name (format "%s#%s" class-name test-case)))
     (meghanada--run-junit test-name)))
 


### PR DESCRIPTION
Couple of little fixes. 

1. I got tired of picking the test case name every time I need to run a test so I've switched `(meghanada-run-junit-test-case)` to using the same imenu function index + `(which-function)` for supplying default input. This speeds up test running by at least a few clicks. 

2. Currently `meghanada-emacs` uses `(thing-at-point 'word)` to get a symbol to jump to, which works most of the time. But Java uses a camel case convention for most of it's code so sometimes people enable `subword-mode` to handle words within a symbol. In this case `(thing-at-point 'word)` retrieves only a part of the current symbol, a subword, which is wrong. I switched to using `(thing-at-point 'symbol)` and that fixed the issue.

BTW, `meghanada-emacs` is great, keep up the great job!