### PR TITLE
Don't override user's company configuration

### DIFF
--- a/company-meghanada.el
+++ b/company-meghanada.el
@@ -63,8 +63,9 @@
   (company-mode t)
   (set (make-local-variable 'company-backends) nil)
   (set (make-local-variable 'company-transformers) nil)
-  (when company-meghanada-prefix-length
-    (set (make-local-variable 'company-minimum-prefix-length) company-meghanada-prefix-length))
+  (if company-meghanada-prefix-length
+      (set (make-local-variable 'company-minimum-prefix-length) company-meghanada-prefix-length)
+    (set (make-local-variable 'company-meghanada-prefix-length) company-minimum-prefix-length))
   (setq company-meghanada-trigger-regex (format company-meghanada--trigger company-meghanada-prefix-length company-meghanada-prefix-length))
   (add-to-list 'company-backends '(company-meghanada :with company-dabbrev-code))
   (setq company-transformers '(company-sort-by-backend-importance))

--- a/company-meghanada.el
+++ b/company-meghanada.el
@@ -48,7 +48,7 @@
   :group 'company-meghanada
   :type 'boolean)
 
-(defcustom company-meghanada-prefix-length 2
+(defcustom company-meghanada-prefix-length nil
   "Start completion prefix-length."
   :group 'company-meghanada
   :type 'integer)
@@ -63,8 +63,8 @@
   (company-mode t)
   (set (make-local-variable 'company-backends) nil)
   (set (make-local-variable 'company-transformers) nil)
-  (set (make-local-variable 'company-idle-delay) 0)
-  (set (make-local-variable 'company-minimum-prefix-length) company-meghanada-prefix-length)
+  (when company-meghanada-prefix-length
+    (set (make-local-variable 'company-minimum-prefix-length) company-meghanada-prefix-length))
   (setq company-meghanada-trigger-regex (format company-meghanada--trigger company-meghanada-prefix-length company-meghanada-prefix-length))
   (add-to-list 'company-backends '(company-meghanada :with company-dabbrev-code))
   (setq company-transformers '(company-sort-by-backend-importance))


### PR DESCRIPTION
This changes meghanada emacs not to override the user's configuration for
`company-idle-delay` and `company-minimum-prefix-length`. `company-idle-delay`
is now set *only* by the user, and `company-minimum-prefix-length` is set if and
only if `company-meghanada-prefix-length` is already configured.

This should resolve #26