### PR TITLE
[meghanada.el] Update  meghanada--task-client-process-filter.

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -547,12 +547,17 @@ function."
 (defun meghanada--task-client-process-filter (ignored output)
   "TODO: FIX DOC IGNORED OUTPUT."
   (let* ((buf meghanada--task-buffer)
-         (eot nil))
+         (eot nil)
+         (current-position (point))
+         (is-at-buffer-end (eq (point-max) current-position)))
     ;; (pop-to-buffer buf)
     (with-current-buffer (get-buffer-create buf)
       (setq buffer-read-only nil)
-      (insert output)
       (goto-char (point-max))
+      (insert output)
+      (if is-at-buffer-end
+          (goto-char (point-max))
+        (goto-char current-position))
       (if (and (string= buf meghanada--junit-buf-name)
                (search-backward meghanada--eot nil t))
           (progn
@@ -566,7 +571,8 @@ function."
             (replace-match "")
             (setq eot t))
           (when eot
-            (compilation-mode)))))))
+            (compilation-mode)))))
+    (setq buffer-read-only t)))
 
 (defun meghanada--process-push-callback (process cb)
   "TODO: FIX DOC PROCESS CB."

--- a/meghanada.el
+++ b/meghanada.el
@@ -547,39 +547,38 @@ function."
 (defun meghanada--task-client-process-filter (ignored output)
   "TODO: FIX DOC IGNORED OUTPUT."
   (let* ((buf meghanada--task-buffer)
+         (return-to-position)
          (eot nil))
     ;; (pop-to-buffer buf)
     (with-current-buffer (get-buffer-create buf)
-      (let* (return-to-position)
-        ;; Make buffer editable
-        (setq buffer-read-only nil)
-        ;; Save current position if it's not the end of the buffer.
-        (unless (eq (point) (point-max))
-          (setq return-to-position (point)))
-        ;; Insert the new output
-        (goto-char (point-max))
-        (insert output)
-        (if (and (string= buf meghanada--junit-buf-name)
-                 (search-backward meghanada--eot nil t))
-            (progn
-              (while (re-search-forward meghanada--eot nil t)
-                (replace-match "")
-                (setq eot t))
-              (when eot
-                (compilation-mode)))
+      ;; Make buffer editable
+      (setq buffer-read-only nil)
+      ;; Save current position if it's not the end of the buffer.
+      (unless (eq (point) (point-max))
+        (setq return-to-position (point)))
+      ;; Insert the new output
+      (goto-char (point-max))
+      (insert output)
+      (if (and (string= buf meghanada--junit-buf-name)
+               (search-backward meghanada--eot nil t))
           (progn
-            (while (re-search-backward meghanada--eot nil t)
+            (while (re-search-forward meghanada--eot nil t)
               (replace-match "")
               (setq eot t))
             (when eot
-              (compilation-mode))))
-        ;; Return to last position or stay at the end of the buffer
-        (if return-to-position
-            (goto-char return-to-position)
-          (set-window-point (get-buffer-window buf) (point-max)))
-        ;; Make buffer read-only again
-        (setq buffer-read-only t)))))
-
+              (compilation-mode)))
+        (progn
+          (while (re-search-backward meghanada--eot nil t)
+            (replace-match "")
+            (setq eot t))
+          (when eot
+            (compilation-mode))))
+      ;; Return to last position or stay at the end of the buffer
+      (if return-to-position
+          (goto-char return-to-position)
+        (set-window-point (get-buffer-window buf) (point-max)))
+      ;; Make buffer read-only again
+      (setq buffer-read-only t))))
 
 (defun meghanada--process-push-callback (process cb)
   "TODO: FIX DOC PROCESS CB."

--- a/meghanada.el
+++ b/meghanada.el
@@ -547,15 +547,18 @@ function."
 (defun meghanada--task-client-process-filter (ignored output)
   "TODO: FIX DOC IGNORED OUTPUT."
   (let* ((buf meghanada--task-buffer)
-         (return-to-position)
+         (buf-window)
+         (initial-point)
          (eot nil))
     ;; (pop-to-buffer buf)
     (with-current-buffer (get-buffer-create buf)
       ;; Make buffer editable
       (setq buffer-read-only nil)
+      ;; Save the task buffer window
+      (setq buf-window (get-buffer-window buf))
       ;; Save current position if it's not the end of the buffer.
       (unless (eq (point) (point-max))
-        (setq return-to-position (point)))
+        (setq initial-point (point)))
       ;; Insert the new output
       (goto-char (point-max))
       (insert output)
@@ -574,9 +577,10 @@ function."
           (when eot
             (compilation-mode))))
       ;; Return to last position or stay at the end of the buffer
-      (if return-to-position
-          (goto-char return-to-position)
-        (set-window-point (get-buffer-window buf) (point-max)))
+      (if initial-point
+          (goto-char initial-point)
+        (if buf-window
+            (set-window-point buf-window (point-max))))
       ;; Make buffer read-only again
       (setq buffer-read-only t))))
 


### PR DESCRIPTION
Three minor improvement:
1) New output will always be inserted at the end of the buffer (Issue #66)
2) Cursor will stay at the end of the buffer if it is positioned
   there, but it will stay in place if it's not. This allows to either
   track new outputs or to read previously printed outputs without
   constantly going at the buffers' end.
3) Task buffer is made read-only again after printing the new output. 

For the third one, I'm not sure if it will impact other stuff, but it feels to me that the user should not be able to write in the task buffer.