### PR TITLE
Do not require match when creating local var

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -851,7 +851,7 @@ function."
       (forward-char -3)
       (if (= len 1)
           (insert (car vals))
-        (let ((res (completing-read "local variable:" vals nil t)))
+        (let ((res (completing-read "local variable:" vals nil nil)))
           (unless (string= res "")
             (insert res)))))))
 


### PR DESCRIPTION
- allow to directly to type a new name in case the default list does not contain
suitable name.