### PR TITLE
Improvements on meghanada--task-client-process-filter

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -187,6 +187,11 @@ The slash is expected at the end."
   :group 'meghanada
   :type 'string)
 
+(defcustom meghanada-task-buffer-auto-scroll t
+  "If true, automatically move to the end of the task buffer after inserting new output."
+  :group 'meghanada
+  :type 'boolean)
+
 ;;
 ;; utility
 ;;
@@ -560,27 +565,39 @@ function."
 
 (defun meghanada--task-client-process-filter (ignored output)
   "TODO: FIX DOC IGNORED OUTPUT."
-  (let* ((buf meghanada--task-buffer)
-         (eot nil))
+  (let ((buf meghanada--task-buffer))
     ;; (pop-to-buffer buf)
     (with-current-buffer (get-buffer-create buf)
-      (setq buffer-read-only nil)
-      (insert output)
-      (goto-char (point-max))
-      (if (and (string= buf meghanada--junit-buf-name)
-               (search-backward meghanada--eot nil t))
-          (progn
-            (while (re-search-forward meghanada--eot nil t)
-              (replace-match "")
-              (setq eot t))
-            (when eot
-              (compilation-mode)))
-        (progn
-          (while (re-search-backward meghanada--eot nil t)
-            (replace-match "")
-            (setq eot t))
-          (when eot
-            (compilation-mode)))))))
+      (let ((win (get-buffer-window buf))
+            (eob (eq (point) (point-max)))
+            (eot nil))
+        ;; Insert the new output at the end of the buffer
+        ;; and restore the buffer point afterward
+        (save-excursion
+          (goto-char (point-max))
+          (setq buffer-read-only nil)
+          (insert output)
+          (if (and (string= buf meghanada--junit-buf-name)
+                   (search-backward meghanada--eot nil t))
+              (progn
+                (while (re-search-forward meghanada--eot nil t)
+                  (replace-match "")
+                  (setq eot t))
+                (when eot
+                  (compilation-mode)))
+            (progn
+              (while (re-search-backward meghanada--eot nil t)
+                (replace-match "")
+                (setq eot t))
+              (when eot
+                (compilation-mode))))
+          (setq buffer-read-only t))
+        ;; If the cursor is already at the end of the buffer or if
+        ;; auto-scrolling is activated, move the cursor to the end of the buffer
+        ;; (moves both buffer point and window point)
+        (when (or meghanada-task-buffer-auto-scroll eob)
+          (goto-char (point-max))
+          (when win (set-window-point win (point))))))))
 
 (defun meghanada--process-push-callback (process cb)
   "TODO: FIX DOC PROCESS CB."


### PR DESCRIPTION
Three minor improvements:
1. New output will always be inserted at the end of the buffer (Issue #66);
2. Cursor will stay at the end of the buffer if it is positioned there, but it
   will stay in place if it's not. This allows to either track new outputs or to
   read previously printed outputs without constantly going at the end of the
   task buffers. An option named `meghanada-task-buffer-auto-scroll` was also
   added. If set to true (the default), the cursor will always stay at the end
   of the task buffer (as it was before);
3. Task buffer is made read-only again after printing the new output.