### PR TITLE
Support smart completion for variable and field member

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ package and [meghanada-server][].
 * Search references
 * Full-featured text search
 
-`Meghanada` is tested under `linux` and `Windows` (maybe macOS OK).
+`Meghanada` is tested under `linux`, `Windows` and `macOS`.
 
 (Welcome contributions !)
 

--- a/company-meghanada.el
+++ b/company-meghanada.el
@@ -198,9 +198,12 @@
                                       (search-backward ".")
                                       (backward-word)
                                       (meghanada--what-word)))))
-                        (if rt
-                            (concat "*method:" rt "#" prefix)
-                          (concat "*" sym "#" prefix))))
+                        (if assign
+                            (if rt (concat "*method:" rt "*" vt "#" prefix)
+                              (concat "*" sym "*" vt "#" prefix))
+                          (if rt (concat "*method:" rt "#" prefix)
+                            (concat "*" sym "#" prefix))
+                          )))
 
                      ((string-match "\\(.*\\)\\.\\(\\w*\\)$" match)
                       (let* ((var (match-string 1 match))

--- a/company-meghanada.el
+++ b/company-meghanada.el
@@ -159,11 +159,11 @@
                           (concat "*method#" prefix))))
 
                      ((string-match "\\.\\(\\w*\\)$" match)
-                      (let* ((paren (meghanada--last-is-paren))
+                      (let* ((prefix (match-string 1 match))
+                             (paren (meghanada--last-is-paren))
                              (rt (if paren
                                      (ignore-errors (meghanada--search-method-caller))
                                    (ignore-errors (meghanada--search-access-caller))))
-                             (prefix (match-string 1 match))
                              (sym (if paren
                                       (save-excursion
                                         (backward-list)

--- a/company-meghanada.el
+++ b/company-meghanada.el
@@ -120,7 +120,8 @@
   (save-excursion
     (search-backward ".")
     (backward-word)
-    (get-text-property (point) 'return-type)))
+    (if (= (meghanada--what-word) "this" "this"
+           (get-text-property (point) 'return-type)))))
 
 (defun meghanada--last-is-paren ()
   (save-excursion


### PR DESCRIPTION
Support smart completion(list methods with return value same as the variable/field to be assigned before other methods):

The current implementation logic is:

For the follow code fragments

```
String a = "";
int i = a. //<-- Cursor position 
```

```
String a = "";
int i = 0;
i = a.
```

```
public class A {
  private int intMember;
  private void aMethod() {
    String a = "";
    intMember = a. //<-- Cursor position 
  }
}
```

then all methods of String class with return type of `int` will be list before other methods.

Current support:

* class member assignment
* local variable assignment

Note:

- For code fragment 2 and 3, the buffer needs to be saved first for the meghanada-server to generate correct output, otherwise the return list will be same as current.
- For code fragment 1, I will sent the type information(int) directly from Emacs to server side for it to do match, so there's no need to save the buffer.

Related issue: https://github.com/mopemope/meghanada-server/issues/51

This pull request is supposed to work together when https://github.com/mopemope/meghanada-server/pull/61 is merged.