### PR TITLE
Always enable meghanada-mode when navigating to files

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -1390,6 +1390,7 @@ e.g. java.lang.annotation)."
       (unless (string= filename (buffer-file-name))
         (funcall #'find-file filename))
 
+      (meghanada-mode t)
       (meghanada--goto-line line)
       (beginning-of-line)
       (forward-char (1- col))


### PR DESCRIPTION
The user may not have enabled meghanada-mode for all .java files. If
this is the case, nagivating into a .java file using
`meghanada-jump-declaration` (M-.) may leave the user unable to navigate
back; without meghanada-mode, M-, would be bound to
`xref-pop-marker-stack` instead of `meghanada-back-jump`.

This commit always enables meghanada-mode, so the user can always
navigate back as expected.