### PR TITLE
Allow meghanada to support hooks after a test is executed

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -250,6 +250,9 @@ In linux or macOS, it can be \"mvn\"; In Windows, it can be \"mvn.cmd\". "
   :group 'meghanada
   :type 'string)
 
+(defcustom meghanada-mode-after-test-hook '()
+  "Hook that is called after a JUnit test execution is done."
+  :group 'meghanada)
 ;;
 ;; utility
 ;;
@@ -758,7 +761,11 @@ function."
                 (setq eot t))
               (when eot
                 (compilation-mode))))
-          (setq buffer-read-only t))
+          (setq buffer-read-only t)
+          ;; Run all after test hooks now that the buffer is read-only
+          (when (string= buffer meghanada--junit-buf-name)
+            (run-hooks 'meghanada-mode-after-test-hook))
+          )
         ;; If the cursor is already at the end of the buffer or if
         ;; auto-scrolling is activated, move the cursor to the end of the buffer
         ;; (moves both buffer point and window point)


### PR DESCRIPTION
Hey @mopemope 

Just wanted to thank you for this package, is great, makes Java development experience somewhat bearable.

I'm adding a functionality to allow interested packages to get notified when a JUnit test-suite finishes. Following is an example of what kind of stuff I do with this hook on my personal setup.

[![meghanada after save example](https://img.youtube.com/vi/zDNYSCHbtCc/0.jpg)](https://youtu.be/zDNYSCHbtCc)

Notice the highlights of the mode-line whenever a test starts executing, a green highlight when it passes and a red highlight when it doesn't.

Thank you for considering this pull request.

