### PR TITLE
Passing the real column position, especially for pretty-symbol-mode

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -261,9 +261,13 @@ In linux or macOS, it can be \"mvn\"; In Windows, it can be \"mvn.cmd\". "
   "TODO: FIX DOC ."
   (format-mode-line "%l"))
 
+(defun meghanada--real-current-column ()
+  "like `current-column', but skip invisible characters in pretty-symbol-mode."
+  (- (point) (line-beginning-position)))
+
 (defun meghanada--what-column ()
   "TODO: FIX DOC ."
-  (number-to-string (1+ (current-column))))
+  (number-to-string (1+ (meghanada--real-current-column))))
 
 (defun meghanada--what-symbol ()
   "TODO: FIX DOC ."


### PR DESCRIPTION
```(current-column)``` does not get the real column number in pretty-symbol-mode, fix it by using
```lisp
(- (point) (line-beginning-position))
```

see the following picture, ***я*** is short for Java's keyword ***return***, ```(current-column)``` 's result is 6, actually the real column position in source code is 10.

![default](https://user-images.githubusercontent.com/5419011/49915078-d11f2f00-fece-11e8-948f-57fb35f9644e.png)
