### PR TITLE
Add support for alternative server locations, Prevent from infinite downloading loop

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -368,17 +368,21 @@ function."
 
 (defun meghanada--download-from-url (url dest-jar)
   "Download a jar file from URL to DEST-JAR Path."
-  (let ((dest meghanada-server-install-dir))
+  (let ((dest meghanada-server-install-dir)
+        (orig-url-handler-mode (bound-and-true-p url-handler-mode)))
     (unless (file-exists-p dest)
       (make-directory dest t))
     (message (format "Download module from %s. Please wait ..." url))
     (url-handler-mode t)
-    (if (file-exists-p url)
-        (progn
-          ;; TODO: Follow redirection
-          (url-copy-file url dest-jar)
-          (message (format "Downloaded module from %s to %s." url dest-jar)))
-      (error "Not found %s" url))))
+    (unwind-protect
+        (if (file-exists-p url)
+            (progn
+              ;; TODO: Follow redirection
+              (url-copy-file url dest-jar)
+              (message (format "Downloaded module from %s to %s." url dest-jar)))
+          (error "Not found %s" url))
+      (unless orig-url-handler-mode
+        (url-handler-mode 0)))))
 
 (defun meghanada--expand-url-template (template)
   "Expand interpolations in TEMPLATE."

--- a/meghanada.el
+++ b/meghanada.el
@@ -442,18 +442,16 @@ function."
 (defun meghanada-install-server ()
   "Install meghanada-server's jar file from bintray ."
   (interactive)
-  (let ((dest-jar (meghanada--locate-server-jar)))
-    (if (file-exists-p dest-jar)
-        nil
-      (condition-case err
-          (progn
-            (meghanada--setup)
-            t)
-        (error
-         (let ((error-buf meghanada--install-err-buf-name))
-           (with-current-buffer (get-buffer-create error-buf)
-             (insert (format "Error: %s" (error-message-string err)))
-             (compilation-mode))))))))
+  (unless (file-exists-p (meghanada--locate-server-jar))
+    (condition-case err
+        (progn
+          (meghanada--setup)
+          t)
+      (error
+       (let ((error-buf meghanada--install-err-buf-name))
+         (with-current-buffer (get-buffer-create error-buf)
+           (insert (format "Error: %s" (error-message-string err)))
+           (compilation-mode)))))))
 
 ;;;###autoload
 (defun meghanada-update-server ()

--- a/meghanada.el
+++ b/meghanada.el
@@ -763,9 +763,9 @@ function."
                 (compilation-mode))))
           (setq buffer-read-only t)
           ;; Run all after test hooks now that the buffer is read-only
-          (when (string= buffer meghanada--junit-buf-name)
-            (run-hooks 'meghanada-mode-after-test-hook))
-          )
+          (when (string= buf meghanada--junit-buf-name)
+            (run-hooks 'meghanada-mode-after-test-hook)))
+
         ;; If the cursor is already at the end of the buffer or if
         ;; auto-scrolling is activated, move the cursor to the end of the buffer
         ;; (moves both buffer point and window point)


### PR DESCRIPTION
Addresses #137.

It seems that you have chosen to let the user manually download `meghanada-XXX.jar`, but I have added support for mirror servers by using `s.el` for expanding interpolated strings. It adds the package as a dependency.

I have also made several changes in process handling and log output, but there can be still room for improvement. I still wonder why you use `meghanada-setup-XXX.jar` to download the jar file. You probably can implemented it simpler if you write it in Emacs Lisp.