### PR TITLE
Download meghanada-XXX.jar without meghanada-setup-XXX.jar

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -442,18 +442,16 @@ function."
 (defun meghanada-install-server ()
   "Install meghanada-server's jar file from bintray ."
   (interactive)
-  (let ((dest-jar (meghanada--locate-server-jar)))
-    (if (file-exists-p dest-jar)
-        nil
-      (condition-case err
-          (progn
-            (meghanada--setup)
-            t)
-        (error
-         (let ((error-buf meghanada--install-err-buf-name))
-           (with-current-buffer (get-buffer-create error-buf)
-             (insert (format "Error: %s" (error-message-string err)))
-             (compilation-mode))))))))
+  (unless (file-exists-p (meghanada--locate-server-jar))
+    (condition-case err
+        (progn
+          (meghanada--setup)
+          t)
+      (error
+       (let ((error-buf meghanada--install-err-buf-name))
+         (with-current-buffer (get-buffer-create error-buf)
+           (insert (format "Error: %s" (error-message-string err)))
+           (compilation-mode)))))))
 
 ;;;###autoload
 (defun meghanada-update-server ()


### PR DESCRIPTION
I've added a branch that doesn't need `meghanada-setup-XXX.jar` to download the server jar. It directly downloads the jar file from either GitHub or bintray.com. 

Note that it doesn't show progress of downloading. It downloads the jar file in the background, but the user can't tell when it is estimated to finish. It just displays a message when it finishes.  