### PR TITLE
Unwrap temporary-file-directory

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -533,7 +533,7 @@ function."
                            (shell-quote-argument jar)
                            meghanada-port
                            (if meghanada-debug "-v" "")
-                           (concat "-l " (temporary-file-directory) "meghanada_server_" (number-to-string (user-uid)) ".log")))
+                           (concat "-l " temporary-file-directory "meghanada_server_" (number-to-string (user-uid)) ".log")))
               process)
           (message (format "launch server cmd:%s" cmd))
           (setq process


### PR DESCRIPTION
Fix #145 
`temporary-file-directory` is a variable and can't be invoked.
It causes `meghanada--start-server-process` to throw an error.
Remove the invoking parentheses.