### PR TITLE
Fix wrong return code in my last commit

### DIFF
--- a/meghanada.el
+++ b/meghanada.el
@@ -427,7 +427,7 @@ function."
              proc
              #'(lambda (process msg)
                  (unless (process-live-p process)
-                   (if (eq 1 (process-exit-status process))
+                   (if (eq 0 (process-exit-status process))
                        (progn
                          (message (format "Success. It downloaded to %s." meghanada-server-install-dir))
                          (pop-to-buffer buf)


### PR DESCRIPTION
In my last commit I have checked the return code of the meghanada install
command fixing one of the endless loops however I did make a mistake there
by expecting a return code of 1 where it should have been 0 instead
to cover all cases.

Sorry for that, here is the corresponding fix.